### PR TITLE
SREP-3938: Add --hive-ocm-url flag to network verify-egress for multi-env OCM support

### DIFF
--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -105,6 +105,8 @@ type EgressVerification struct {
 	Namespace string
 	// SkipServiceLog disables automatic service log prompting on verification failures
 	SkipServiceLog bool
+	// hiveOcmUrl is the OCM environment URL for Hive operations (Classic clusters only)
+	hiveOcmUrl string
 }
 
 func NewCmdValidateEgress() *cobra.Command {
@@ -165,6 +167,11 @@ func NewCmdValidateEgress() *cobra.Command {
   # Run network verification without sending service logs on failure
   osdctl network verify-egress --cluster-id my-rosa-cluster --skip-service-log
 
+  # Run against a staging cluster using production Hive (multi-environment OCM)
+  export OCM_URL=staging
+  ocm login
+  osdctl network verify-egress --cluster-id my-staging-cluster --hive-ocm-url production
+
   # (Not recommended) Run against a specific VPC, without specifying cluster-id
   <export environment variables like AWS_ACCESS_KEY_ID or use aws configure>
   osdctl network verify-egress --subnet-id subnet-abcdefg123 --security-group sg-abcdefgh123 --region us-east-1`,
@@ -195,6 +202,7 @@ func NewCmdValidateEgress() *cobra.Command {
 	validateEgressCmd.Flags().StringVar(&e.KubeConfig, "kubeconfig", "", "(optional) path to kubeconfig file for pod mode (uses default kubeconfig if not specified)")
 	validateEgressCmd.Flags().StringVar(&e.Namespace, "namespace", "openshift-network-diagnostics", "(optional) Kubernetes namespace to run verification pods in")
 	validateEgressCmd.Flags().BoolVar(&e.SkipServiceLog, "skip-service-log", false, "(optional) disable automatic service log sending when verification fails")
+	validateEgressCmd.Flags().StringVar(&e.hiveOcmUrl, "hive-ocm-url", "", "(optional) OCM environment URL for hive operations. Aliases: 'production', 'staging', 'integration'. If not specified, uses the same OCM environment as the target cluster.")
 
 	return validateEgressCmd
 }
@@ -444,15 +452,48 @@ func (e *EgressVerification) getCaBundleFromHive(ctx context.Context) (string, e
 		return "", err
 	}
 
-	hive, err := utils.GetHiveCluster(e.cluster.ID())
-	if err != nil {
-		return "", err
-	}
+	var hive *cmv1.Cluster
+	var hc client.Client
+	var err error
 
-	e.log.Debug(ctx, "assembling K8s client for %s (%s)", hive.ID(), hive.Name())
-	hc, err := k8s.New(hive.ID(), client.Options{Scheme: scheme})
-	if err != nil {
-		return "", err
+	if e.hiveOcmUrl != "" {
+		// Multi-environment path - enables staging/integration testing
+		targetOCM, err := utils.CreateConnection()
+		if err != nil {
+			return "", fmt.Errorf("failed to create target OCM connection: %w", err)
+		}
+		defer targetOCM.Close()
+
+		hiveOCM, err := utils.CreateConnectionWithUrl(e.hiveOcmUrl)
+		if err != nil {
+			return "", fmt.Errorf("failed to create hive OCM connection with URL '%s': %w", e.hiveOcmUrl, err)
+		}
+		defer hiveOCM.Close()
+
+		e.log.Debug(ctx, "using multi-environment OCM: target cluster OCM and hive OCM URL '%s'", e.hiveOcmUrl)
+
+		hive, err = utils.GetHiveClusterWithConn(e.cluster.ID(), targetOCM, hiveOCM)
+		if err != nil {
+			return "", fmt.Errorf("failed to get hive cluster (OCM URL:'%s'): %w", e.hiveOcmUrl, err)
+		}
+
+		e.log.Debug(ctx, "assembling K8s client for %s (%s)", hive.ID(), hive.Name())
+		hc, err = k8s.NewWithConn(hive.ID(), client.Options{Scheme: scheme}, hiveOCM)
+		if err != nil {
+			return "", fmt.Errorf("failed to create hive k8s client (OCM URL:'%s'): %w", e.hiveOcmUrl, err)
+		}
+	} else {
+		// Original path - backward compatible
+		hive, err = utils.GetHiveCluster(e.cluster.ID())
+		if err != nil {
+			return "", err
+		}
+
+		e.log.Debug(ctx, "assembling K8s client for %s (%s)", hive.ID(), hive.Name())
+		hc, err = k8s.New(hive.ID(), client.Options{Scheme: scheme})
+		if err != nil {
+			return "", err
+		}
 	}
 
 	e.log.Debug(ctx, "searching for proxy SyncSet")
@@ -621,6 +662,14 @@ func (e *EgressVerification) validateInput() error {
 			if strings.HasPrefix(strings.ToLower(e.platformName), "aws") {
 				return fmt.Errorf("pod mode for AWS platforms requires --region when --cluster-id is not specified")
 			}
+		}
+	}
+
+	// Validate --hive-ocm-url if provided
+	if e.hiveOcmUrl != "" {
+		_, err := utils.ValidateAndResolveOcmUrl(e.hiveOcmUrl)
+		if err != nil {
+			return fmt.Errorf("invalid --hive-ocm-url: %w", err)
 		}
 	}
 

--- a/cmd/network/verification_test.go
+++ b/cmd/network/verification_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/openshift/osd-network-verifier/pkg/probes/curl"
 	onv "github.com/openshift/osd-network-verifier/pkg/verifier"
 	"github.com/openshift/osdctl/cmd/servicelog"
+	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,6 +75,46 @@ func TestEgressVerification_ValidateInput(t *testing.T) {
 			},
 			wantError: false,
 		},
+		{
+			name: "valid_hive_ocm_url_production",
+			ev: &EgressVerification{
+				SubnetIds:  []string{"subnet-123"},
+				hiveOcmUrl: "production",
+			},
+			wantError: false,
+		},
+		{
+			name: "valid_hive_ocm_url_staging",
+			ev: &EgressVerification{
+				SubnetIds:  []string{"subnet-123"},
+				hiveOcmUrl: "staging",
+			},
+			wantError: false,
+		},
+		{
+			name: "valid_hive_ocm_url_integration",
+			ev: &EgressVerification{
+				SubnetIds:  []string{"subnet-123"},
+				hiveOcmUrl: "integration",
+			},
+			wantError: false,
+		},
+		{
+			name: "valid_hive_ocm_url_full_url",
+			ev: &EgressVerification{
+				SubnetIds:  []string{"subnet-123"},
+				hiveOcmUrl: "https://api.openshift.com",
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid_hive_ocm_url",
+			ev: &EgressVerification{
+				SubnetIds:  []string{"subnet-123"},
+				hiveOcmUrl: "invalid-environment",
+			},
+			wantError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -82,6 +124,73 @@ func TestEgressVerification_ValidateInput(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestHiveOcmUrlValidation tests the validation of --hive-ocm-url flag
+func TestHiveOcmUrlValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		hiveOcmUrl  string
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:       "Valid hive-ocm-url (production)",
+			hiveOcmUrl: "production",
+			expectErr:  false,
+		},
+		{
+			name:       "Valid hive-ocm-url (staging)",
+			hiveOcmUrl: "staging",
+			expectErr:  false,
+		},
+		{
+			name:       "Valid hive-ocm-url (integration)",
+			hiveOcmUrl: "integration",
+			expectErr:  false,
+		},
+		{
+			name:       "Valid hive-ocm-url (full URL)",
+			hiveOcmUrl: "https://api.openshift.com",
+			expectErr:  false,
+		},
+		{
+			name:        "Invalid hive-ocm-url",
+			hiveOcmUrl:  "invalid-environment",
+			expectErr:   true,
+			errContains: "invalid OCM_URL",
+		},
+		{
+			name:        "Empty hive-ocm-url",
+			hiveOcmUrl:  "",
+			expectErr:   true,
+			errContains: "empty OCM URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This simulates the validation that occurs in the validateInput() method
+			var err error
+			if tt.hiveOcmUrl != "" {
+				_, err = utils.ValidateAndResolveOcmUrl(tt.hiveOcmUrl)
+			} else {
+				_, err = utils.ValidateAndResolveOcmUrl(tt.hiveOcmUrl)
+			}
+
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("Expected error containing '%s', but got nil", tt.errContains)
+				} else if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("Expected error containing '%s', but got: %v", tt.errContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error, but got: %v", err)
+				}
 			}
 		})
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -3589,6 +3589,7 @@ osdctl network verify-egress [flags]
       --egress-timeout duration          (optional) timeout for individual egress verification requests (default 5s)
       --gcp-project-id string            (optional) the GCP project ID to run verification for
   -h, --help                             help for verify-egress
+      --hive-ocm-url string              (optional) OCM environment URL for hive operations. Aliases: 'production', 'staging', 'integration'. If not specified, uses the same OCM environment as the target cluster.
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                (optional) path to kubeconfig file for pod mode (uses default kubeconfig if not specified)
       --namespace string                 (optional) Kubernetes namespace to run verification pods in (default "openshift-network-diagnostics")

--- a/docs/osdctl_network_verify-egress.md
+++ b/docs/osdctl_network_verify-egress.md
@@ -64,6 +64,11 @@ osdctl network verify-egress [flags]
   # Run network verification without sending service logs on failure
   osdctl network verify-egress --cluster-id my-rosa-cluster --skip-service-log
 
+  # Run against a staging cluster using production Hive (multi-environment OCM)
+  export OCM_URL=staging
+  ocm login
+  osdctl network verify-egress --cluster-id my-staging-cluster --hive-ocm-url production
+
   # (Not recommended) Run against a specific VPC, without specifying cluster-id
   <export environment variables like AWS_ACCESS_KEY_ID or use aws configure>
   osdctl network verify-egress --subnet-id subnet-abcdefg123 --security-group sg-abcdefgh123 --region us-east-1
@@ -80,6 +85,7 @@ osdctl network verify-egress [flags]
       --egress-timeout duration   (optional) timeout for individual egress verification requests (default 5s)
       --gcp-project-id string     (optional) the GCP project ID to run verification for
   -h, --help                      help for verify-egress
+      --hive-ocm-url string       (optional) OCM environment URL for hive operations. Aliases: 'production', 'staging', 'integration'. If not specified, uses the same OCM environment as the target cluster.
       --kubeconfig string         (optional) path to kubeconfig file for pod mode (uses default kubeconfig if not specified)
       --namespace string          (optional) Kubernetes namespace to run verification pods in (default "openshift-network-diagnostics")
       --no-tls                    (optional) if provided, ignore all ssl certificate validations on client-side.


### PR DESCRIPTION
## Summary

Adds `--hive-ocm-url` flag to `osdctl network verify-egress` command to enable multi-environment OCM support for staging/integration testing.

## Changes

- Added `--hive-ocm-url` optional flag to network verify-egress command
- Implements conditional logic to use separate OCM connections for target cluster and hive when flag is provided
- Added early validation in `validateInput()` method to fail fast on invalid OCM URLs
- Preserves backward compatibility - original code path unchanged when flag not provided
- Supports OCM URL aliases: 'production', 'staging', 'integration'
- Updated unit tests in `verification_test.go` to verify early validation behavior

## Implementation Details

When `--hive-ocm-url` is specified:
1. Creates separate OCM connection for hive using `utils.CreateConnectionWithUrl()`
2. Uses `utils.GetHiveClusterWithConn()` to query hive from different OCM environment
3. Creates hive k8s client with appropriate OCM connection
4. Validates OCM URL early using `utils.ValidateAndResolveOcmUrl()`

## Testing

- ✅ Tested in staging environment with valid --hive-ocm-url values
- ✅ Tested in production environment with valid --hive-ocm-url values
- ✅ Validated early failure with invalid --hive-ocm-url values
- ✅ Backward compatibility verified (command works without --hive-ocm-url flag)
- ✅ Unit tests passing (including new tests for validation logic)

### Testing Limitation

⚠️ **Note**: The code path that actually uses Hive with `--hive-ocm-url` requires a cluster configured with a cluster-wide proxy. No such clusters were available for testing in either staging or production environments. The implementation follows the same pattern as other commands in this series (SREP-3940, SREP-3941, SREP-3896) and has been verified through code review and unit tests.

## Related

- Parent Epic: [SREP-3936](https://issues.redhat.com/browse/SREP-3936)
- Jira: [SREP-3938](https://issues.redhat.com/browse/SREP-3938)

## Note

This PR is part of a series adding multi-environment OCM support to osdctl commands. Will place on hold until the common implementation pattern can be reviewed across all related PRs.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>